### PR TITLE
Force rows to overlap a little

### DIFF
--- a/src/components/harp-row/harp-row-styles.ts
+++ b/src/components/harp-row/harp-row-styles.ts
@@ -25,6 +25,7 @@ export const getStyles = (
       justifyContent: 'space-around',
       alignItems: 'center',
       borderColor: inertOutline,
+      top: isBlowRow(yCoord, activeHarpStrata) ? 1 : 0,
       borderTopWidth: isBlowRow(yCoord, activeHarpStrata) ? borderWidth : 0,
       borderBottomWidth: isDrawRow(yCoord, activeHarpStrata) ? borderWidth : 0,
       borderRightWidth: isBlowOrDrawRow(yCoord, activeHarpStrata)


### PR DESCRIPTION
this means that the boundary between the two rows is overlaped slightly
meaning that there is no chance of a rendering issue leaving the
background visible at the boundary.

It's a compromise because it means that the gap between the blow and the
blowbend rows is slightly larger than the others but it's such a small
difference at this is such a quick fix that it's a fair trade off.