### PR TITLE
Add momoization to the HarpFace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to ~~[Semantic Versioning](https://semver.org/spec/v2.0
 - INITIAL-DEVELOPMENT: Introduce ReactN to enable the use of some global state
 - INITIAL-DEVELOPMENT: Add a quiz mode
 - INITIAL-DEVELOPMENT: Add context dependant sizing
+- INITIAL-DEVELOPMENT: Add memoisation of HarpFace
 
 ### Changed
 - INITIAL-DEVELOPMENT: Enhance menu UX

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to ~~[Semantic Versioning](https://semver.org/spec/v2.0
 - INITIAL-DEVELOPMENT: Add memoisation of HarpFace
 
 ### Changed
+
 - INITIAL-DEVELOPMENT: Enhance menu UX
 - INITIAL-DEVELOPMENT: Present both sharp and flat version of Pitch
 

--- a/src/components/harp-cell/__snapshots__/harp-cell.test.tsx.snap
+++ b/src/components/harp-cell/__snapshots__/harp-cell.test.tsx.snap
@@ -23,9 +23,9 @@ exports[`A snapshot of a populated cell 1`] = `
         "borderWidth": 1.8748172966652428,
         "elevation": 0,
         "flexDirection": "row",
-        "height": 62.37517146005262,
+        "height": 67.28344314272223,
         "justifyContent": "center",
-        "width": 62.37517146005262,
+        "width": 67.28344314272223,
       }
     }
   >
@@ -108,9 +108,9 @@ exports[`A snapshot of an active cell 1`] = `
         "borderWidth": 1.8748172966652428,
         "elevation": 3.033454386004363,
         "flexDirection": "row",
-        "height": 62.37517146005262,
+        "height": 67.28344314272223,
         "justifyContent": "center",
-        "width": 62.37517146005262,
+        "width": 67.28344314272223,
       }
     }
   >
@@ -191,9 +191,9 @@ exports[`A snapshot of an empty cell 1`] = `
         "borderWidth": 0,
         "elevation": 0,
         "flexDirection": "row",
-        "height": 62.37517146005262,
+        "height": 67.28344314272223,
         "justifyContent": "center",
-        "width": 62.37517146005262,
+        "width": 67.28344314272223,
       }
     }
   >
@@ -207,9 +207,9 @@ exports[`A snapshot of an empty cell 1`] = `
           "borderWidth": 0,
           "elevation": 0,
           "flexDirection": "row",
-          "height": 62.37517146005262,
+          "height": 67.28344314272223,
           "justifyContent": "center",
-          "width": 62.37517146005262,
+          "width": 67.28344314272223,
         }
       }
     />
@@ -240,9 +240,9 @@ exports[`A snapshot of an inactive cell in Explore mode 1`] = `
         "borderWidth": 1.8748172966652428,
         "elevation": 0,
         "flexDirection": "row",
-        "height": 62.37517146005262,
+        "height": 67.28344314272223,
         "justifyContent": "center",
-        "width": 62.37517146005262,
+        "width": 67.28344314272223,
       }
     }
   >
@@ -325,9 +325,9 @@ exports[`A snapshot of an inactive cell in Quiz mode 1`] = `
         "borderWidth": 1.8748172966652428,
         "elevation": 0,
         "flexDirection": "row",
-        "height": 62.37517146005262,
+        "height": 67.28344314272223,
         "justifyContent": "center",
-        "width": 62.37517146005262,
+        "width": 67.28344314272223,
       }
     }
   >

--- a/src/components/harp-face-fragment/__snapshots__/harp-face-fragment.test.tsx.snap
+++ b/src/components/harp-face-fragment/__snapshots__/harp-face-fragment.test.tsx.snap
@@ -49,9 +49,9 @@ exports[`A snapshot of a HarpFaceFragment 1`] = `
             "borderWidth": 0,
             "elevation": 0,
             "flexDirection": "row",
-            "height": 62.37517146005262,
+            "height": 67.28344314272223,
             "justifyContent": "center",
-            "width": 62.37517146005262,
+            "width": 67.28344314272223,
           }
         }
       >
@@ -65,9 +65,9 @@ exports[`A snapshot of a HarpFaceFragment 1`] = `
               "borderWidth": 0,
               "elevation": 0,
               "flexDirection": "row",
-              "height": 62.37517146005262,
+              "height": 67.28344314272223,
               "justifyContent": "center",
-              "width": 62.37517146005262,
+              "width": 67.28344314272223,
             }
           }
         />
@@ -83,9 +83,9 @@ exports[`A snapshot of a HarpFaceFragment 1`] = `
             "borderWidth": 0,
             "elevation": 0,
             "flexDirection": "row",
-            "height": 62.37517146005262,
+            "height": 67.28344314272223,
             "justifyContent": "center",
-            "width": 62.37517146005262,
+            "width": 67.28344314272223,
           }
         }
       >
@@ -99,9 +99,9 @@ exports[`A snapshot of a HarpFaceFragment 1`] = `
               "borderWidth": 0,
               "elevation": 0,
               "flexDirection": "row",
-              "height": 62.37517146005262,
+              "height": 67.28344314272223,
               "justifyContent": "center",
-              "width": 62.37517146005262,
+              "width": 67.28344314272223,
             }
           }
         />
@@ -117,9 +117,9 @@ exports[`A snapshot of a HarpFaceFragment 1`] = `
             "borderWidth": 0,
             "elevation": 0,
             "flexDirection": "row",
-            "height": 62.37517146005262,
+            "height": 67.28344314272223,
             "justifyContent": "center",
-            "width": 62.37517146005262,
+            "width": 67.28344314272223,
           }
         }
       >
@@ -133,9 +133,9 @@ exports[`A snapshot of a HarpFaceFragment 1`] = `
               "borderWidth": 0,
               "elevation": 0,
               "flexDirection": "row",
-              "height": 62.37517146005262,
+              "height": 67.28344314272223,
               "justifyContent": "center",
-              "width": 62.37517146005262,
+              "width": 67.28344314272223,
             }
           }
         />
@@ -151,9 +151,9 @@ exports[`A snapshot of a HarpFaceFragment 1`] = `
             "borderWidth": 0,
             "elevation": 0,
             "flexDirection": "row",
-            "height": 62.37517146005262,
+            "height": 67.28344314272223,
             "justifyContent": "center",
-            "width": 62.37517146005262,
+            "width": 67.28344314272223,
           }
         }
       >
@@ -167,9 +167,9 @@ exports[`A snapshot of a HarpFaceFragment 1`] = `
               "borderWidth": 0,
               "elevation": 0,
               "flexDirection": "row",
-              "height": 62.37517146005262,
+              "height": 67.28344314272223,
               "justifyContent": "center",
-              "width": 62.37517146005262,
+              "width": 67.28344314272223,
             }
           }
         />
@@ -185,9 +185,9 @@ exports[`A snapshot of a HarpFaceFragment 1`] = `
             "borderWidth": 0,
             "elevation": 0,
             "flexDirection": "row",
-            "height": 62.37517146005262,
+            "height": 67.28344314272223,
             "justifyContent": "center",
-            "width": 62.37517146005262,
+            "width": 67.28344314272223,
           }
         }
       >
@@ -201,9 +201,9 @@ exports[`A snapshot of a HarpFaceFragment 1`] = `
               "borderWidth": 0,
               "elevation": 0,
               "flexDirection": "row",
-              "height": 62.37517146005262,
+              "height": 67.28344314272223,
               "justifyContent": "center",
-              "width": 62.37517146005262,
+              "width": 67.28344314272223,
             }
           }
         />
@@ -219,9 +219,9 @@ exports[`A snapshot of a HarpFaceFragment 1`] = `
             "borderWidth": 0,
             "elevation": 0,
             "flexDirection": "row",
-            "height": 62.37517146005262,
+            "height": 67.28344314272223,
             "justifyContent": "center",
-            "width": 62.37517146005262,
+            "width": 67.28344314272223,
           }
         }
       >
@@ -235,9 +235,9 @@ exports[`A snapshot of a HarpFaceFragment 1`] = `
               "borderWidth": 0,
               "elevation": 0,
               "flexDirection": "row",
-              "height": 62.37517146005262,
+              "height": 67.28344314272223,
               "justifyContent": "center",
-              "width": 62.37517146005262,
+              "width": 67.28344314272223,
             }
           }
         />
@@ -253,9 +253,9 @@ exports[`A snapshot of a HarpFaceFragment 1`] = `
             "borderWidth": 0,
             "elevation": 0,
             "flexDirection": "row",
-            "height": 62.37517146005262,
+            "height": 67.28344314272223,
             "justifyContent": "center",
-            "width": 62.37517146005262,
+            "width": 67.28344314272223,
           }
         }
       >
@@ -269,9 +269,9 @@ exports[`A snapshot of a HarpFaceFragment 1`] = `
               "borderWidth": 0,
               "elevation": 0,
               "flexDirection": "row",
-              "height": 62.37517146005262,
+              "height": 67.28344314272223,
               "justifyContent": "center",
-              "width": 62.37517146005262,
+              "width": 67.28344314272223,
             }
           }
         />
@@ -287,9 +287,9 @@ exports[`A snapshot of a HarpFaceFragment 1`] = `
             "borderWidth": 0,
             "elevation": 0,
             "flexDirection": "row",
-            "height": 62.37517146005262,
+            "height": 67.28344314272223,
             "justifyContent": "center",
-            "width": 62.37517146005262,
+            "width": 67.28344314272223,
           }
         }
       >
@@ -303,9 +303,9 @@ exports[`A snapshot of a HarpFaceFragment 1`] = `
               "borderWidth": 0,
               "elevation": 0,
               "flexDirection": "row",
-              "height": 62.37517146005262,
+              "height": 67.28344314272223,
               "justifyContent": "center",
-              "width": 62.37517146005262,
+              "width": 67.28344314272223,
             }
           }
         />
@@ -321,9 +321,9 @@ exports[`A snapshot of a HarpFaceFragment 1`] = `
             "borderWidth": 0,
             "elevation": 0,
             "flexDirection": "row",
-            "height": 62.37517146005262,
+            "height": 67.28344314272223,
             "justifyContent": "center",
-            "width": 62.37517146005262,
+            "width": 67.28344314272223,
           }
         }
       >
@@ -337,9 +337,9 @@ exports[`A snapshot of a HarpFaceFragment 1`] = `
               "borderWidth": 0,
               "elevation": 0,
               "flexDirection": "row",
-              "height": 62.37517146005262,
+              "height": 67.28344314272223,
               "justifyContent": "center",
-              "width": 62.37517146005262,
+              "width": 67.28344314272223,
             }
           }
         />
@@ -357,9 +357,9 @@ exports[`A snapshot of a HarpFaceFragment 1`] = `
             "borderWidth": 1.8748172966652428,
             "elevation": 0,
             "flexDirection": "row",
-            "height": 62.37517146005262,
+            "height": 67.28344314272223,
             "justifyContent": "center",
-            "width": 62.37517146005262,
+            "width": 67.28344314272223,
           }
         }
       >
@@ -450,9 +450,9 @@ exports[`A snapshot of a HarpFaceFragment 1`] = `
             "borderWidth": 1.8748172966652428,
             "elevation": 0,
             "flexDirection": "row",
-            "height": 62.37517146005262,
+            "height": 67.28344314272223,
             "justifyContent": "center",
-            "width": 62.37517146005262,
+            "width": 67.28344314272223,
           }
         }
       >
@@ -520,9 +520,9 @@ exports[`A snapshot of a HarpFaceFragment 1`] = `
             "borderWidth": 0,
             "elevation": 0,
             "flexDirection": "row",
-            "height": 62.37517146005262,
+            "height": 67.28344314272223,
             "justifyContent": "center",
-            "width": 62.37517146005262,
+            "width": 67.28344314272223,
           }
         }
       >
@@ -536,9 +536,9 @@ exports[`A snapshot of a HarpFaceFragment 1`] = `
               "borderWidth": 0,
               "elevation": 0,
               "flexDirection": "row",
-              "height": 62.37517146005262,
+              "height": 67.28344314272223,
               "justifyContent": "center",
-              "width": 62.37517146005262,
+              "width": 67.28344314272223,
             }
           }
         />
@@ -554,9 +554,9 @@ exports[`A snapshot of a HarpFaceFragment 1`] = `
             "borderWidth": 0,
             "elevation": 0,
             "flexDirection": "row",
-            "height": 62.37517146005262,
+            "height": 67.28344314272223,
             "justifyContent": "center",
-            "width": 62.37517146005262,
+            "width": 67.28344314272223,
           }
         }
       >
@@ -570,9 +570,9 @@ exports[`A snapshot of a HarpFaceFragment 1`] = `
               "borderWidth": 0,
               "elevation": 0,
               "flexDirection": "row",
-              "height": 62.37517146005262,
+              "height": 67.28344314272223,
               "justifyContent": "center",
-              "width": 62.37517146005262,
+              "width": 67.28344314272223,
             }
           }
         />
@@ -590,9 +590,9 @@ exports[`A snapshot of a HarpFaceFragment 1`] = `
             "borderWidth": 1.8748172966652428,
             "elevation": 0,
             "flexDirection": "row",
-            "height": 62.37517146005262,
+            "height": 67.28344314272223,
             "justifyContent": "center",
-            "width": 62.37517146005262,
+            "width": 67.28344314272223,
           }
         }
       >
@@ -662,9 +662,9 @@ exports[`A snapshot of a HarpFaceFragment 1`] = `
             "borderWidth": 1.8748172966652428,
             "elevation": 0,
             "flexDirection": "row",
-            "height": 62.37517146005262,
+            "height": 67.28344314272223,
             "justifyContent": "center",
-            "width": 62.37517146005262,
+            "width": 67.28344314272223,
           }
         }
       >
@@ -734,9 +734,9 @@ exports[`A snapshot of a HarpFaceFragment 1`] = `
             "borderWidth": 1.8748172966652428,
             "elevation": 0,
             "flexDirection": "row",
-            "height": 62.37517146005262,
+            "height": 67.28344314272223,
             "justifyContent": "center",
-            "width": 62.37517146005262,
+            "width": 67.28344314272223,
           }
         }
       >
@@ -804,9 +804,9 @@ exports[`A snapshot of a HarpFaceFragment 1`] = `
             "borderWidth": 0,
             "elevation": 0,
             "flexDirection": "row",
-            "height": 62.37517146005262,
+            "height": 67.28344314272223,
             "justifyContent": "center",
-            "width": 62.37517146005262,
+            "width": 67.28344314272223,
           }
         }
       >
@@ -820,9 +820,9 @@ exports[`A snapshot of a HarpFaceFragment 1`] = `
               "borderWidth": 0,
               "elevation": 0,
               "flexDirection": "row",
-              "height": 62.37517146005262,
+              "height": 67.28344314272223,
               "justifyContent": "center",
-              "width": 62.37517146005262,
+              "width": 67.28344314272223,
             }
           }
         />
@@ -840,9 +840,9 @@ exports[`A snapshot of a HarpFaceFragment 1`] = `
             "borderWidth": 1.8748172966652428,
             "elevation": 0,
             "flexDirection": "row",
-            "height": 62.37517146005262,
+            "height": 67.28344314272223,
             "justifyContent": "center",
-            "width": 62.37517146005262,
+            "width": 67.28344314272223,
           }
         }
       >
@@ -912,9 +912,9 @@ exports[`A snapshot of a HarpFaceFragment 1`] = `
             "borderWidth": 1.8748172966652428,
             "elevation": 0,
             "flexDirection": "row",
-            "height": 62.37517146005262,
+            "height": 67.28344314272223,
             "justifyContent": "center",
-            "width": 62.37517146005262,
+            "width": 67.28344314272223,
           }
         }
       >
@@ -984,9 +984,9 @@ exports[`A snapshot of a HarpFaceFragment 1`] = `
             "borderWidth": 1.8748172966652428,
             "elevation": 0,
             "flexDirection": "row",
-            "height": 62.37517146005262,
+            "height": 67.28344314272223,
             "justifyContent": "center",
-            "width": 62.37517146005262,
+            "width": 67.28344314272223,
           }
         }
       >
@@ -1077,9 +1077,9 @@ exports[`A snapshot of a HarpFaceFragment 1`] = `
             "borderWidth": 1.8748172966652428,
             "elevation": 0,
             "flexDirection": "row",
-            "height": 62.37517146005262,
+            "height": 67.28344314272223,
             "justifyContent": "center",
-            "width": 62.37517146005262,
+            "width": 67.28344314272223,
           }
         }
       >
@@ -1149,9 +1149,9 @@ exports[`A snapshot of a HarpFaceFragment 1`] = `
             "borderWidth": 1.8748172966652428,
             "elevation": 0,
             "flexDirection": "row",
-            "height": 62.37517146005262,
+            "height": 67.28344314272223,
             "justifyContent": "center",
-            "width": 62.37517146005262,
+            "width": 67.28344314272223,
           }
         }
       >
@@ -1221,9 +1221,9 @@ exports[`A snapshot of a HarpFaceFragment 1`] = `
             "borderWidth": 1.8748172966652428,
             "elevation": 0,
             "flexDirection": "row",
-            "height": 62.37517146005262,
+            "height": 67.28344314272223,
             "justifyContent": "center",
-            "width": 62.37517146005262,
+            "width": 67.28344314272223,
           }
         }
       >
@@ -1293,9 +1293,9 @@ exports[`A snapshot of a HarpFaceFragment 1`] = `
             "borderWidth": 1.8748172966652428,
             "elevation": 0,
             "flexDirection": "row",
-            "height": 62.37517146005262,
+            "height": 67.28344314272223,
             "justifyContent": "center",
-            "width": 62.37517146005262,
+            "width": 67.28344314272223,
           }
         }
       >
@@ -1365,9 +1365,9 @@ exports[`A snapshot of a HarpFaceFragment 1`] = `
             "borderWidth": 1.8748172966652428,
             "elevation": 0,
             "flexDirection": "row",
-            "height": 62.37517146005262,
+            "height": 67.28344314272223,
             "justifyContent": "center",
-            "width": 62.37517146005262,
+            "width": 67.28344314272223,
           }
         }
       >
@@ -1437,9 +1437,9 @@ exports[`A snapshot of a HarpFaceFragment 1`] = `
             "borderWidth": 1.8748172966652428,
             "elevation": 0,
             "flexDirection": "row",
-            "height": 62.37517146005262,
+            "height": 67.28344314272223,
             "justifyContent": "center",
-            "width": 62.37517146005262,
+            "width": 67.28344314272223,
           }
         }
       >
@@ -1509,9 +1509,9 @@ exports[`A snapshot of a HarpFaceFragment 1`] = `
             "borderWidth": 1.8748172966652428,
             "elevation": 0,
             "flexDirection": "row",
-            "height": 62.37517146005262,
+            "height": 67.28344314272223,
             "justifyContent": "center",
-            "width": 62.37517146005262,
+            "width": 67.28344314272223,
           }
         }
       >
@@ -1581,9 +1581,9 @@ exports[`A snapshot of a HarpFaceFragment 1`] = `
             "borderWidth": 1.8748172966652428,
             "elevation": 0,
             "flexDirection": "row",
-            "height": 62.37517146005262,
+            "height": 67.28344314272223,
             "justifyContent": "center",
-            "width": 62.37517146005262,
+            "width": 67.28344314272223,
           }
         }
       >
@@ -1653,9 +1653,9 @@ exports[`A snapshot of a HarpFaceFragment 1`] = `
             "borderWidth": 1.8748172966652428,
             "elevation": 0,
             "flexDirection": "row",
-            "height": 62.37517146005262,
+            "height": 67.28344314272223,
             "justifyContent": "center",
-            "width": 62.37517146005262,
+            "width": 67.28344314272223,
           }
         }
       >
@@ -1725,9 +1725,9 @@ exports[`A snapshot of a HarpFaceFragment 1`] = `
             "borderWidth": 1.8748172966652428,
             "elevation": 0,
             "flexDirection": "row",
-            "height": 62.37517146005262,
+            "height": 67.28344314272223,
             "justifyContent": "center",
-            "width": 62.37517146005262,
+            "width": 67.28344314272223,
           }
         }
       >
@@ -2040,9 +2040,9 @@ exports[`A snapshot of a HarpFaceFragment 1`] = `
             "borderWidth": 1.8748172966652428,
             "elevation": 0,
             "flexDirection": "row",
-            "height": 62.37517146005262,
+            "height": 67.28344314272223,
             "justifyContent": "center",
-            "width": 62.37517146005262,
+            "width": 67.28344314272223,
           }
         }
       >
@@ -2112,9 +2112,9 @@ exports[`A snapshot of a HarpFaceFragment 1`] = `
             "borderWidth": 1.8748172966652428,
             "elevation": 0,
             "flexDirection": "row",
-            "height": 62.37517146005262,
+            "height": 67.28344314272223,
             "justifyContent": "center",
-            "width": 62.37517146005262,
+            "width": 67.28344314272223,
           }
         }
       >
@@ -2184,9 +2184,9 @@ exports[`A snapshot of a HarpFaceFragment 1`] = `
             "borderWidth": 1.8748172966652428,
             "elevation": 0,
             "flexDirection": "row",
-            "height": 62.37517146005262,
+            "height": 67.28344314272223,
             "justifyContent": "center",
-            "width": 62.37517146005262,
+            "width": 67.28344314272223,
           }
         }
       >
@@ -2256,9 +2256,9 @@ exports[`A snapshot of a HarpFaceFragment 1`] = `
             "borderWidth": 1.8748172966652428,
             "elevation": 0,
             "flexDirection": "row",
-            "height": 62.37517146005262,
+            "height": 67.28344314272223,
             "justifyContent": "center",
-            "width": 62.37517146005262,
+            "width": 67.28344314272223,
           }
         }
       >
@@ -2328,9 +2328,9 @@ exports[`A snapshot of a HarpFaceFragment 1`] = `
             "borderWidth": 1.8748172966652428,
             "elevation": 0,
             "flexDirection": "row",
-            "height": 62.37517146005262,
+            "height": 67.28344314272223,
             "justifyContent": "center",
-            "width": 62.37517146005262,
+            "width": 67.28344314272223,
           }
         }
       >
@@ -2400,9 +2400,9 @@ exports[`A snapshot of a HarpFaceFragment 1`] = `
             "borderWidth": 1.8748172966652428,
             "elevation": 0,
             "flexDirection": "row",
-            "height": 62.37517146005262,
+            "height": 67.28344314272223,
             "justifyContent": "center",
-            "width": 62.37517146005262,
+            "width": 67.28344314272223,
           }
         }
       >
@@ -2472,9 +2472,9 @@ exports[`A snapshot of a HarpFaceFragment 1`] = `
             "borderWidth": 1.8748172966652428,
             "elevation": 0,
             "flexDirection": "row",
-            "height": 62.37517146005262,
+            "height": 67.28344314272223,
             "justifyContent": "center",
-            "width": 62.37517146005262,
+            "width": 67.28344314272223,
           }
         }
       >
@@ -2544,9 +2544,9 @@ exports[`A snapshot of a HarpFaceFragment 1`] = `
             "borderWidth": 1.8748172966652428,
             "elevation": 0,
             "flexDirection": "row",
-            "height": 62.37517146005262,
+            "height": 67.28344314272223,
             "justifyContent": "center",
-            "width": 62.37517146005262,
+            "width": 67.28344314272223,
           }
         }
       >
@@ -2616,9 +2616,9 @@ exports[`A snapshot of a HarpFaceFragment 1`] = `
             "borderWidth": 1.8748172966652428,
             "elevation": 0,
             "flexDirection": "row",
-            "height": 62.37517146005262,
+            "height": 67.28344314272223,
             "justifyContent": "center",
-            "width": 62.37517146005262,
+            "width": 67.28344314272223,
           }
         }
       >
@@ -2688,9 +2688,9 @@ exports[`A snapshot of a HarpFaceFragment 1`] = `
             "borderWidth": 1.8748172966652428,
             "elevation": 0,
             "flexDirection": "row",
-            "height": 62.37517146005262,
+            "height": 67.28344314272223,
             "justifyContent": "center",
-            "width": 62.37517146005262,
+            "width": 67.28344314272223,
           }
         }
       >
@@ -2781,9 +2781,9 @@ exports[`A snapshot of a HarpFaceFragment 1`] = `
             "borderWidth": 1.8748172966652428,
             "elevation": 0,
             "flexDirection": "row",
-            "height": 62.37517146005262,
+            "height": 67.28344314272223,
             "justifyContent": "center",
-            "width": 62.37517146005262,
+            "width": 67.28344314272223,
           }
         }
       >
@@ -2853,9 +2853,9 @@ exports[`A snapshot of a HarpFaceFragment 1`] = `
             "borderWidth": 1.8748172966652428,
             "elevation": 0,
             "flexDirection": "row",
-            "height": 62.37517146005262,
+            "height": 67.28344314272223,
             "justifyContent": "center",
-            "width": 62.37517146005262,
+            "width": 67.28344314272223,
           }
         }
       >
@@ -2925,9 +2925,9 @@ exports[`A snapshot of a HarpFaceFragment 1`] = `
             "borderWidth": 1.8748172966652428,
             "elevation": 0,
             "flexDirection": "row",
-            "height": 62.37517146005262,
+            "height": 67.28344314272223,
             "justifyContent": "center",
-            "width": 62.37517146005262,
+            "width": 67.28344314272223,
           }
         }
       >
@@ -2997,9 +2997,9 @@ exports[`A snapshot of a HarpFaceFragment 1`] = `
             "borderWidth": 1.8748172966652428,
             "elevation": 0,
             "flexDirection": "row",
-            "height": 62.37517146005262,
+            "height": 67.28344314272223,
             "justifyContent": "center",
-            "width": 62.37517146005262,
+            "width": 67.28344314272223,
           }
         }
       >
@@ -3067,9 +3067,9 @@ exports[`A snapshot of a HarpFaceFragment 1`] = `
             "borderWidth": 0,
             "elevation": 0,
             "flexDirection": "row",
-            "height": 62.37517146005262,
+            "height": 67.28344314272223,
             "justifyContent": "center",
-            "width": 62.37517146005262,
+            "width": 67.28344314272223,
           }
         }
       >
@@ -3083,9 +3083,9 @@ exports[`A snapshot of a HarpFaceFragment 1`] = `
               "borderWidth": 0,
               "elevation": 0,
               "flexDirection": "row",
-              "height": 62.37517146005262,
+              "height": 67.28344314272223,
               "justifyContent": "center",
-              "width": 62.37517146005262,
+              "width": 67.28344314272223,
             }
           }
         />
@@ -3103,9 +3103,9 @@ exports[`A snapshot of a HarpFaceFragment 1`] = `
             "borderWidth": 1.8748172966652428,
             "elevation": 0,
             "flexDirection": "row",
-            "height": 62.37517146005262,
+            "height": 67.28344314272223,
             "justifyContent": "center",
-            "width": 62.37517146005262,
+            "width": 67.28344314272223,
           }
         }
       >
@@ -3175,9 +3175,9 @@ exports[`A snapshot of a HarpFaceFragment 1`] = `
             "borderWidth": 1.8748172966652428,
             "elevation": 0,
             "flexDirection": "row",
-            "height": 62.37517146005262,
+            "height": 67.28344314272223,
             "justifyContent": "center",
-            "width": 62.37517146005262,
+            "width": 67.28344314272223,
           }
         }
       >
@@ -3245,9 +3245,9 @@ exports[`A snapshot of a HarpFaceFragment 1`] = `
             "borderWidth": 0,
             "elevation": 0,
             "flexDirection": "row",
-            "height": 62.37517146005262,
+            "height": 67.28344314272223,
             "justifyContent": "center",
-            "width": 62.37517146005262,
+            "width": 67.28344314272223,
           }
         }
       >
@@ -3261,9 +3261,9 @@ exports[`A snapshot of a HarpFaceFragment 1`] = `
               "borderWidth": 0,
               "elevation": 0,
               "flexDirection": "row",
-              "height": 62.37517146005262,
+              "height": 67.28344314272223,
               "justifyContent": "center",
-              "width": 62.37517146005262,
+              "width": 67.28344314272223,
             }
           }
         />
@@ -3281,9 +3281,9 @@ exports[`A snapshot of a HarpFaceFragment 1`] = `
             "borderWidth": 1.8748172966652428,
             "elevation": 0,
             "flexDirection": "row",
-            "height": 62.37517146005262,
+            "height": 67.28344314272223,
             "justifyContent": "center",
-            "width": 62.37517146005262,
+            "width": 67.28344314272223,
           }
         }
       >
@@ -3353,9 +3353,9 @@ exports[`A snapshot of a HarpFaceFragment 1`] = `
             "borderWidth": 1.8748172966652428,
             "elevation": 0,
             "flexDirection": "row",
-            "height": 62.37517146005262,
+            "height": 67.28344314272223,
             "justifyContent": "center",
-            "width": 62.37517146005262,
+            "width": 67.28344314272223,
           }
         }
       >
@@ -3444,9 +3444,9 @@ exports[`A snapshot of a HarpFaceFragment 1`] = `
             "borderWidth": 0,
             "elevation": 0,
             "flexDirection": "row",
-            "height": 62.37517146005262,
+            "height": 67.28344314272223,
             "justifyContent": "center",
-            "width": 62.37517146005262,
+            "width": 67.28344314272223,
           }
         }
       >
@@ -3460,9 +3460,9 @@ exports[`A snapshot of a HarpFaceFragment 1`] = `
               "borderWidth": 0,
               "elevation": 0,
               "flexDirection": "row",
-              "height": 62.37517146005262,
+              "height": 67.28344314272223,
               "justifyContent": "center",
-              "width": 62.37517146005262,
+              "width": 67.28344314272223,
             }
           }
         />
@@ -3480,9 +3480,9 @@ exports[`A snapshot of a HarpFaceFragment 1`] = `
             "borderWidth": 1.8748172966652428,
             "elevation": 0,
             "flexDirection": "row",
-            "height": 62.37517146005262,
+            "height": 67.28344314272223,
             "justifyContent": "center",
-            "width": 62.37517146005262,
+            "width": 67.28344314272223,
           }
         }
       >
@@ -3552,9 +3552,9 @@ exports[`A snapshot of a HarpFaceFragment 1`] = `
             "borderWidth": 1.8748172966652428,
             "elevation": 0,
             "flexDirection": "row",
-            "height": 62.37517146005262,
+            "height": 67.28344314272223,
             "justifyContent": "center",
-            "width": 62.37517146005262,
+            "width": 67.28344314272223,
           }
         }
       >
@@ -3622,9 +3622,9 @@ exports[`A snapshot of a HarpFaceFragment 1`] = `
             "borderWidth": 0,
             "elevation": 0,
             "flexDirection": "row",
-            "height": 62.37517146005262,
+            "height": 67.28344314272223,
             "justifyContent": "center",
-            "width": 62.37517146005262,
+            "width": 67.28344314272223,
           }
         }
       >
@@ -3638,9 +3638,9 @@ exports[`A snapshot of a HarpFaceFragment 1`] = `
               "borderWidth": 0,
               "elevation": 0,
               "flexDirection": "row",
-              "height": 62.37517146005262,
+              "height": 67.28344314272223,
               "justifyContent": "center",
-              "width": 62.37517146005262,
+              "width": 67.28344314272223,
             }
           }
         />
@@ -3656,9 +3656,9 @@ exports[`A snapshot of a HarpFaceFragment 1`] = `
             "borderWidth": 0,
             "elevation": 0,
             "flexDirection": "row",
-            "height": 62.37517146005262,
+            "height": 67.28344314272223,
             "justifyContent": "center",
-            "width": 62.37517146005262,
+            "width": 67.28344314272223,
           }
         }
       >
@@ -3672,9 +3672,9 @@ exports[`A snapshot of a HarpFaceFragment 1`] = `
               "borderWidth": 0,
               "elevation": 0,
               "flexDirection": "row",
-              "height": 62.37517146005262,
+              "height": 67.28344314272223,
               "justifyContent": "center",
-              "width": 62.37517146005262,
+              "width": 67.28344314272223,
             }
           }
         />
@@ -3690,9 +3690,9 @@ exports[`A snapshot of a HarpFaceFragment 1`] = `
             "borderWidth": 0,
             "elevation": 0,
             "flexDirection": "row",
-            "height": 62.37517146005262,
+            "height": 67.28344314272223,
             "justifyContent": "center",
-            "width": 62.37517146005262,
+            "width": 67.28344314272223,
           }
         }
       >
@@ -3706,9 +3706,9 @@ exports[`A snapshot of a HarpFaceFragment 1`] = `
               "borderWidth": 0,
               "elevation": 0,
               "flexDirection": "row",
-              "height": 62.37517146005262,
+              "height": 67.28344314272223,
               "justifyContent": "center",
-              "width": 62.37517146005262,
+              "width": 67.28344314272223,
             }
           }
         />
@@ -3724,9 +3724,9 @@ exports[`A snapshot of a HarpFaceFragment 1`] = `
             "borderWidth": 0,
             "elevation": 0,
             "flexDirection": "row",
-            "height": 62.37517146005262,
+            "height": 67.28344314272223,
             "justifyContent": "center",
-            "width": 62.37517146005262,
+            "width": 67.28344314272223,
           }
         }
       >
@@ -3740,9 +3740,9 @@ exports[`A snapshot of a HarpFaceFragment 1`] = `
               "borderWidth": 0,
               "elevation": 0,
               "flexDirection": "row",
-              "height": 62.37517146005262,
+              "height": 67.28344314272223,
               "justifyContent": "center",
-              "width": 62.37517146005262,
+              "width": 67.28344314272223,
             }
           }
         />
@@ -3758,9 +3758,9 @@ exports[`A snapshot of a HarpFaceFragment 1`] = `
             "borderWidth": 0,
             "elevation": 0,
             "flexDirection": "row",
-            "height": 62.37517146005262,
+            "height": 67.28344314272223,
             "justifyContent": "center",
-            "width": 62.37517146005262,
+            "width": 67.28344314272223,
           }
         }
       >
@@ -3774,9 +3774,9 @@ exports[`A snapshot of a HarpFaceFragment 1`] = `
               "borderWidth": 0,
               "elevation": 0,
               "flexDirection": "row",
-              "height": 62.37517146005262,
+              "height": 67.28344314272223,
               "justifyContent": "center",
-              "width": 62.37517146005262,
+              "width": 67.28344314272223,
             }
           }
         />
@@ -3792,9 +3792,9 @@ exports[`A snapshot of a HarpFaceFragment 1`] = `
             "borderWidth": 0,
             "elevation": 0,
             "flexDirection": "row",
-            "height": 62.37517146005262,
+            "height": 67.28344314272223,
             "justifyContent": "center",
-            "width": 62.37517146005262,
+            "width": 67.28344314272223,
           }
         }
       >
@@ -3808,9 +3808,9 @@ exports[`A snapshot of a HarpFaceFragment 1`] = `
               "borderWidth": 0,
               "elevation": 0,
               "flexDirection": "row",
-              "height": 62.37517146005262,
+              "height": 67.28344314272223,
               "justifyContent": "center",
-              "width": 62.37517146005262,
+              "width": 67.28344314272223,
             }
           }
         />
@@ -3826,9 +3826,9 @@ exports[`A snapshot of a HarpFaceFragment 1`] = `
             "borderWidth": 0,
             "elevation": 0,
             "flexDirection": "row",
-            "height": 62.37517146005262,
+            "height": 67.28344314272223,
             "justifyContent": "center",
-            "width": 62.37517146005262,
+            "width": 67.28344314272223,
           }
         }
       >
@@ -3842,9 +3842,9 @@ exports[`A snapshot of a HarpFaceFragment 1`] = `
               "borderWidth": 0,
               "elevation": 0,
               "flexDirection": "row",
-              "height": 62.37517146005262,
+              "height": 67.28344314272223,
               "justifyContent": "center",
-              "width": 62.37517146005262,
+              "width": 67.28344314272223,
             }
           }
         />
@@ -3881,9 +3881,9 @@ exports[`A snapshot of a HarpFaceFragment 1`] = `
             "borderWidth": 0,
             "elevation": 0,
             "flexDirection": "row",
-            "height": 62.37517146005262,
+            "height": 67.28344314272223,
             "justifyContent": "center",
-            "width": 62.37517146005262,
+            "width": 67.28344314272223,
           }
         }
       >
@@ -3897,9 +3897,9 @@ exports[`A snapshot of a HarpFaceFragment 1`] = `
               "borderWidth": 0,
               "elevation": 0,
               "flexDirection": "row",
-              "height": 62.37517146005262,
+              "height": 67.28344314272223,
               "justifyContent": "center",
-              "width": 62.37517146005262,
+              "width": 67.28344314272223,
             }
           }
         />
@@ -3915,9 +3915,9 @@ exports[`A snapshot of a HarpFaceFragment 1`] = `
             "borderWidth": 0,
             "elevation": 0,
             "flexDirection": "row",
-            "height": 62.37517146005262,
+            "height": 67.28344314272223,
             "justifyContent": "center",
-            "width": 62.37517146005262,
+            "width": 67.28344314272223,
           }
         }
       >
@@ -3931,9 +3931,9 @@ exports[`A snapshot of a HarpFaceFragment 1`] = `
               "borderWidth": 0,
               "elevation": 0,
               "flexDirection": "row",
-              "height": 62.37517146005262,
+              "height": 67.28344314272223,
               "justifyContent": "center",
-              "width": 62.37517146005262,
+              "width": 67.28344314272223,
             }
           }
         />
@@ -3951,9 +3951,9 @@ exports[`A snapshot of a HarpFaceFragment 1`] = `
             "borderWidth": 1.8748172966652428,
             "elevation": 0,
             "flexDirection": "row",
-            "height": 62.37517146005262,
+            "height": 67.28344314272223,
             "justifyContent": "center",
-            "width": 62.37517146005262,
+            "width": 67.28344314272223,
           }
         }
       >
@@ -4021,9 +4021,9 @@ exports[`A snapshot of a HarpFaceFragment 1`] = `
             "borderWidth": 0,
             "elevation": 0,
             "flexDirection": "row",
-            "height": 62.37517146005262,
+            "height": 67.28344314272223,
             "justifyContent": "center",
-            "width": 62.37517146005262,
+            "width": 67.28344314272223,
           }
         }
       >
@@ -4037,9 +4037,9 @@ exports[`A snapshot of a HarpFaceFragment 1`] = `
               "borderWidth": 0,
               "elevation": 0,
               "flexDirection": "row",
-              "height": 62.37517146005262,
+              "height": 67.28344314272223,
               "justifyContent": "center",
-              "width": 62.37517146005262,
+              "width": 67.28344314272223,
             }
           }
         />
@@ -4055,9 +4055,9 @@ exports[`A snapshot of a HarpFaceFragment 1`] = `
             "borderWidth": 0,
             "elevation": 0,
             "flexDirection": "row",
-            "height": 62.37517146005262,
+            "height": 67.28344314272223,
             "justifyContent": "center",
-            "width": 62.37517146005262,
+            "width": 67.28344314272223,
           }
         }
       >
@@ -4071,9 +4071,9 @@ exports[`A snapshot of a HarpFaceFragment 1`] = `
               "borderWidth": 0,
               "elevation": 0,
               "flexDirection": "row",
-              "height": 62.37517146005262,
+              "height": 67.28344314272223,
               "justifyContent": "center",
-              "width": 62.37517146005262,
+              "width": 67.28344314272223,
             }
           }
         />
@@ -4089,9 +4089,9 @@ exports[`A snapshot of a HarpFaceFragment 1`] = `
             "borderWidth": 0,
             "elevation": 0,
             "flexDirection": "row",
-            "height": 62.37517146005262,
+            "height": 67.28344314272223,
             "justifyContent": "center",
-            "width": 62.37517146005262,
+            "width": 67.28344314272223,
           }
         }
       >
@@ -4105,9 +4105,9 @@ exports[`A snapshot of a HarpFaceFragment 1`] = `
               "borderWidth": 0,
               "elevation": 0,
               "flexDirection": "row",
-              "height": 62.37517146005262,
+              "height": 67.28344314272223,
               "justifyContent": "center",
-              "width": 62.37517146005262,
+              "width": 67.28344314272223,
             }
           }
         />
@@ -4123,9 +4123,9 @@ exports[`A snapshot of a HarpFaceFragment 1`] = `
             "borderWidth": 0,
             "elevation": 0,
             "flexDirection": "row",
-            "height": 62.37517146005262,
+            "height": 67.28344314272223,
             "justifyContent": "center",
-            "width": 62.37517146005262,
+            "width": 67.28344314272223,
           }
         }
       >
@@ -4139,9 +4139,9 @@ exports[`A snapshot of a HarpFaceFragment 1`] = `
               "borderWidth": 0,
               "elevation": 0,
               "flexDirection": "row",
-              "height": 62.37517146005262,
+              "height": 67.28344314272223,
               "justifyContent": "center",
-              "width": 62.37517146005262,
+              "width": 67.28344314272223,
             }
           }
         />
@@ -4157,9 +4157,9 @@ exports[`A snapshot of a HarpFaceFragment 1`] = `
             "borderWidth": 0,
             "elevation": 0,
             "flexDirection": "row",
-            "height": 62.37517146005262,
+            "height": 67.28344314272223,
             "justifyContent": "center",
-            "width": 62.37517146005262,
+            "width": 67.28344314272223,
           }
         }
       >
@@ -4173,9 +4173,9 @@ exports[`A snapshot of a HarpFaceFragment 1`] = `
               "borderWidth": 0,
               "elevation": 0,
               "flexDirection": "row",
-              "height": 62.37517146005262,
+              "height": 67.28344314272223,
               "justifyContent": "center",
-              "width": 62.37517146005262,
+              "width": 67.28344314272223,
             }
           }
         />
@@ -4191,9 +4191,9 @@ exports[`A snapshot of a HarpFaceFragment 1`] = `
             "borderWidth": 0,
             "elevation": 0,
             "flexDirection": "row",
-            "height": 62.37517146005262,
+            "height": 67.28344314272223,
             "justifyContent": "center",
-            "width": 62.37517146005262,
+            "width": 67.28344314272223,
           }
         }
       >
@@ -4207,9 +4207,9 @@ exports[`A snapshot of a HarpFaceFragment 1`] = `
               "borderWidth": 0,
               "elevation": 0,
               "flexDirection": "row",
-              "height": 62.37517146005262,
+              "height": 67.28344314272223,
               "justifyContent": "center",
-              "width": 62.37517146005262,
+              "width": 67.28344314272223,
             }
           }
         />
@@ -4225,9 +4225,9 @@ exports[`A snapshot of a HarpFaceFragment 1`] = `
             "borderWidth": 0,
             "elevation": 0,
             "flexDirection": "row",
-            "height": 62.37517146005262,
+            "height": 67.28344314272223,
             "justifyContent": "center",
-            "width": 62.37517146005262,
+            "width": 67.28344314272223,
           }
         }
       >
@@ -4241,9 +4241,9 @@ exports[`A snapshot of a HarpFaceFragment 1`] = `
               "borderWidth": 0,
               "elevation": 0,
               "flexDirection": "row",
-              "height": 62.37517146005262,
+              "height": 67.28344314272223,
               "justifyContent": "center",
-              "width": 62.37517146005262,
+              "width": 67.28344314272223,
             }
           }
         />

--- a/src/components/harp-face/__snapshots__/harp-face.test.tsx.snap
+++ b/src/components/harp-face/__snapshots__/harp-face.test.tsx.snap
@@ -59,9 +59,9 @@ exports[`A component is rendered 1`] = `
               "borderWidth": 0,
               "elevation": 0,
               "flexDirection": "row",
-              "height": 62.37517146005262,
+              "height": 67.28344314272223,
               "justifyContent": "center",
-              "width": 62.37517146005262,
+              "width": 67.28344314272223,
             }
           }
         >
@@ -75,9 +75,9 @@ exports[`A component is rendered 1`] = `
                 "borderWidth": 0,
                 "elevation": 0,
                 "flexDirection": "row",
-                "height": 62.37517146005262,
+                "height": 67.28344314272223,
                 "justifyContent": "center",
-                "width": 62.37517146005262,
+                "width": 67.28344314272223,
               }
             }
           />
@@ -93,9 +93,9 @@ exports[`A component is rendered 1`] = `
               "borderWidth": 0,
               "elevation": 0,
               "flexDirection": "row",
-              "height": 62.37517146005262,
+              "height": 67.28344314272223,
               "justifyContent": "center",
-              "width": 62.37517146005262,
+              "width": 67.28344314272223,
             }
           }
         >
@@ -109,9 +109,9 @@ exports[`A component is rendered 1`] = `
                 "borderWidth": 0,
                 "elevation": 0,
                 "flexDirection": "row",
-                "height": 62.37517146005262,
+                "height": 67.28344314272223,
                 "justifyContent": "center",
-                "width": 62.37517146005262,
+                "width": 67.28344314272223,
               }
             }
           />
@@ -127,9 +127,9 @@ exports[`A component is rendered 1`] = `
               "borderWidth": 0,
               "elevation": 0,
               "flexDirection": "row",
-              "height": 62.37517146005262,
+              "height": 67.28344314272223,
               "justifyContent": "center",
-              "width": 62.37517146005262,
+              "width": 67.28344314272223,
             }
           }
         >
@@ -143,9 +143,9 @@ exports[`A component is rendered 1`] = `
                 "borderWidth": 0,
                 "elevation": 0,
                 "flexDirection": "row",
-                "height": 62.37517146005262,
+                "height": 67.28344314272223,
                 "justifyContent": "center",
-                "width": 62.37517146005262,
+                "width": 67.28344314272223,
               }
             }
           />
@@ -184,9 +184,9 @@ exports[`A component is rendered 1`] = `
               "borderWidth": 1.8748172966652428,
               "elevation": 0,
               "flexDirection": "row",
-              "height": 62.37517146005262,
+              "height": 67.28344314272223,
               "justifyContent": "center",
-              "width": 62.37517146005262,
+              "width": 67.28344314272223,
             }
           }
         >
@@ -254,9 +254,9 @@ exports[`A component is rendered 1`] = `
               "borderWidth": 0,
               "elevation": 0,
               "flexDirection": "row",
-              "height": 62.37517146005262,
+              "height": 67.28344314272223,
               "justifyContent": "center",
-              "width": 62.37517146005262,
+              "width": 67.28344314272223,
             }
           }
         >
@@ -270,9 +270,9 @@ exports[`A component is rendered 1`] = `
                 "borderWidth": 0,
                 "elevation": 0,
                 "flexDirection": "row",
-                "height": 62.37517146005262,
+                "height": 67.28344314272223,
                 "justifyContent": "center",
-                "width": 62.37517146005262,
+                "width": 67.28344314272223,
               }
             }
           />
@@ -288,9 +288,9 @@ exports[`A component is rendered 1`] = `
               "borderWidth": 0,
               "elevation": 0,
               "flexDirection": "row",
-              "height": 62.37517146005262,
+              "height": 67.28344314272223,
               "justifyContent": "center",
-              "width": 62.37517146005262,
+              "width": 67.28344314272223,
             }
           }
         >
@@ -304,9 +304,9 @@ exports[`A component is rendered 1`] = `
                 "borderWidth": 0,
                 "elevation": 0,
                 "flexDirection": "row",
-                "height": 62.37517146005262,
+                "height": 67.28344314272223,
                 "justifyContent": "center",
-                "width": 62.37517146005262,
+                "width": 67.28344314272223,
               }
             }
           />
@@ -345,9 +345,9 @@ exports[`A component is rendered 1`] = `
               "borderWidth": 1.8748172966652428,
               "elevation": 0,
               "flexDirection": "row",
-              "height": 62.37517146005262,
+              "height": 67.28344314272223,
               "justifyContent": "center",
-              "width": 62.37517146005262,
+              "width": 67.28344314272223,
             }
           }
         >
@@ -417,9 +417,9 @@ exports[`A component is rendered 1`] = `
               "borderWidth": 1.8748172966652428,
               "elevation": 0,
               "flexDirection": "row",
-              "height": 62.37517146005262,
+              "height": 67.28344314272223,
               "justifyContent": "center",
-              "width": 62.37517146005262,
+              "width": 67.28344314272223,
             }
           }
         >
@@ -489,9 +489,9 @@ exports[`A component is rendered 1`] = `
               "borderWidth": 1.8748172966652428,
               "elevation": 0,
               "flexDirection": "row",
-              "height": 62.37517146005262,
+              "height": 67.28344314272223,
               "justifyContent": "center",
-              "width": 62.37517146005262,
+              "width": 67.28344314272223,
             }
           }
         >
@@ -657,9 +657,9 @@ exports[`A component is rendered 1`] = `
               "borderWidth": 1.8748172966652428,
               "elevation": 0,
               "flexDirection": "row",
-              "height": 62.37517146005262,
+              "height": 67.28344314272223,
               "justifyContent": "center",
-              "width": 62.37517146005262,
+              "width": 67.28344314272223,
             }
           }
         >
@@ -729,9 +729,9 @@ exports[`A component is rendered 1`] = `
               "borderWidth": 1.8748172966652428,
               "elevation": 0,
               "flexDirection": "row",
-              "height": 62.37517146005262,
+              "height": 67.28344314272223,
               "justifyContent": "center",
-              "width": 62.37517146005262,
+              "width": 67.28344314272223,
             }
           }
         >
@@ -801,9 +801,9 @@ exports[`A component is rendered 1`] = `
               "borderWidth": 1.8748172966652428,
               "elevation": 0,
               "flexDirection": "row",
-              "height": 62.37517146005262,
+              "height": 67.28344314272223,
               "justifyContent": "center",
-              "width": 62.37517146005262,
+              "width": 67.28344314272223,
             }
           }
         >
@@ -894,9 +894,9 @@ exports[`A component is rendered 1`] = `
               "borderWidth": 1.8748172966652428,
               "elevation": 0,
               "flexDirection": "row",
-              "height": 62.37517146005262,
+              "height": 67.28344314272223,
               "justifyContent": "center",
-              "width": 62.37517146005262,
+              "width": 67.28344314272223,
             }
           }
         >
@@ -966,9 +966,9 @@ exports[`A component is rendered 1`] = `
               "borderWidth": 1.8748172966652428,
               "elevation": 0,
               "flexDirection": "row",
-              "height": 62.37517146005262,
+              "height": 67.28344314272223,
               "justifyContent": "center",
-              "width": 62.37517146005262,
+              "width": 67.28344314272223,
             }
           }
         >
@@ -1038,9 +1038,9 @@ exports[`A component is rendered 1`] = `
               "borderWidth": 1.8748172966652428,
               "elevation": 0,
               "flexDirection": "row",
-              "height": 62.37517146005262,
+              "height": 67.28344314272223,
               "justifyContent": "center",
-              "width": 62.37517146005262,
+              "width": 67.28344314272223,
             }
           }
         >
@@ -1129,9 +1129,9 @@ exports[`A component is rendered 1`] = `
               "borderWidth": 0,
               "elevation": 0,
               "flexDirection": "row",
-              "height": 62.37517146005262,
+              "height": 67.28344314272223,
               "justifyContent": "center",
-              "width": 62.37517146005262,
+              "width": 67.28344314272223,
             }
           }
         >
@@ -1145,9 +1145,9 @@ exports[`A component is rendered 1`] = `
                 "borderWidth": 0,
                 "elevation": 0,
                 "flexDirection": "row",
-                "height": 62.37517146005262,
+                "height": 67.28344314272223,
                 "justifyContent": "center",
-                "width": 62.37517146005262,
+                "width": 67.28344314272223,
               }
             }
           />
@@ -1165,9 +1165,9 @@ exports[`A component is rendered 1`] = `
               "borderWidth": 1.8748172966652428,
               "elevation": 0,
               "flexDirection": "row",
-              "height": 62.37517146005262,
+              "height": 67.28344314272223,
               "justifyContent": "center",
-              "width": 62.37517146005262,
+              "width": 67.28344314272223,
             }
           }
         >
@@ -1237,9 +1237,9 @@ exports[`A component is rendered 1`] = `
               "borderWidth": 1.8748172966652428,
               "elevation": 0,
               "flexDirection": "row",
-              "height": 62.37517146005262,
+              "height": 67.28344314272223,
               "justifyContent": "center",
-              "width": 62.37517146005262,
+              "width": 67.28344314272223,
             }
           }
         >
@@ -1328,9 +1328,9 @@ exports[`A component is rendered 1`] = `
               "borderWidth": 0,
               "elevation": 0,
               "flexDirection": "row",
-              "height": 62.37517146005262,
+              "height": 67.28344314272223,
               "justifyContent": "center",
-              "width": 62.37517146005262,
+              "width": 67.28344314272223,
             }
           }
         >
@@ -1344,9 +1344,9 @@ exports[`A component is rendered 1`] = `
                 "borderWidth": 0,
                 "elevation": 0,
                 "flexDirection": "row",
-                "height": 62.37517146005262,
+                "height": 67.28344314272223,
                 "justifyContent": "center",
-                "width": 62.37517146005262,
+                "width": 67.28344314272223,
               }
             }
           />
@@ -1362,9 +1362,9 @@ exports[`A component is rendered 1`] = `
               "borderWidth": 0,
               "elevation": 0,
               "flexDirection": "row",
-              "height": 62.37517146005262,
+              "height": 67.28344314272223,
               "justifyContent": "center",
-              "width": 62.37517146005262,
+              "width": 67.28344314272223,
             }
           }
         >
@@ -1378,9 +1378,9 @@ exports[`A component is rendered 1`] = `
                 "borderWidth": 0,
                 "elevation": 0,
                 "flexDirection": "row",
-                "height": 62.37517146005262,
+                "height": 67.28344314272223,
                 "justifyContent": "center",
-                "width": 62.37517146005262,
+                "width": 67.28344314272223,
               }
             }
           />
@@ -1398,9 +1398,9 @@ exports[`A component is rendered 1`] = `
               "borderWidth": 1.8748172966652428,
               "elevation": 0,
               "flexDirection": "row",
-              "height": 62.37517146005262,
+              "height": 67.28344314272223,
               "justifyContent": "center",
-              "width": 62.37517146005262,
+              "width": 67.28344314272223,
             }
           }
         >
@@ -1498,9 +1498,9 @@ exports[`A component is rendered 1`] = `
               "borderWidth": 0,
               "elevation": 0,
               "flexDirection": "row",
-              "height": 62.37517146005262,
+              "height": 67.28344314272223,
               "justifyContent": "center",
-              "width": 62.37517146005262,
+              "width": 67.28344314272223,
             }
           }
         >
@@ -1514,9 +1514,9 @@ exports[`A component is rendered 1`] = `
                 "borderWidth": 0,
                 "elevation": 0,
                 "flexDirection": "row",
-                "height": 62.37517146005262,
+                "height": 67.28344314272223,
                 "justifyContent": "center",
-                "width": 62.37517146005262,
+                "width": 67.28344314272223,
               }
             }
           />
@@ -1532,9 +1532,9 @@ exports[`A component is rendered 1`] = `
               "borderWidth": 0,
               "elevation": 0,
               "flexDirection": "row",
-              "height": 62.37517146005262,
+              "height": 67.28344314272223,
               "justifyContent": "center",
-              "width": 62.37517146005262,
+              "width": 67.28344314272223,
             }
           }
         >
@@ -1548,9 +1548,9 @@ exports[`A component is rendered 1`] = `
                 "borderWidth": 0,
                 "elevation": 0,
                 "flexDirection": "row",
-                "height": 62.37517146005262,
+                "height": 67.28344314272223,
                 "justifyContent": "center",
-                "width": 62.37517146005262,
+                "width": 67.28344314272223,
               }
             }
           />
@@ -1566,9 +1566,9 @@ exports[`A component is rendered 1`] = `
               "borderWidth": 0,
               "elevation": 0,
               "flexDirection": "row",
-              "height": 62.37517146005262,
+              "height": 67.28344314272223,
               "justifyContent": "center",
-              "width": 62.37517146005262,
+              "width": 67.28344314272223,
             }
           }
         >
@@ -1582,9 +1582,9 @@ exports[`A component is rendered 1`] = `
                 "borderWidth": 0,
                 "elevation": 0,
                 "flexDirection": "row",
-                "height": 62.37517146005262,
+                "height": 67.28344314272223,
                 "justifyContent": "center",
-                "width": 62.37517146005262,
+                "width": 67.28344314272223,
               }
             }
           />
@@ -1623,9 +1623,9 @@ exports[`A component is rendered 1`] = `
               "borderWidth": 1.8748172966652428,
               "elevation": 0,
               "flexDirection": "row",
-              "height": 62.37517146005262,
+              "height": 67.28344314272223,
               "justifyContent": "center",
-              "width": 62.37517146005262,
+              "width": 67.28344314272223,
             }
           }
         >
@@ -1695,9 +1695,9 @@ exports[`A component is rendered 1`] = `
               "borderWidth": 1.8748172966652428,
               "elevation": 0,
               "flexDirection": "row",
-              "height": 62.37517146005262,
+              "height": 67.28344314272223,
               "justifyContent": "center",
-              "width": 62.37517146005262,
+              "width": 67.28344314272223,
             }
           }
         >
@@ -1767,9 +1767,9 @@ exports[`A component is rendered 1`] = `
               "borderWidth": 1.8748172966652428,
               "elevation": 0,
               "flexDirection": "row",
-              "height": 62.37517146005262,
+              "height": 67.28344314272223,
               "justifyContent": "center",
-              "width": 62.37517146005262,
+              "width": 67.28344314272223,
             }
           }
         >
@@ -1860,9 +1860,9 @@ exports[`A component is rendered 1`] = `
               "borderWidth": 1.8748172966652428,
               "elevation": 0,
               "flexDirection": "row",
-              "height": 62.37517146005262,
+              "height": 67.28344314272223,
               "justifyContent": "center",
-              "width": 62.37517146005262,
+              "width": 67.28344314272223,
             }
           }
         >
@@ -1932,9 +1932,9 @@ exports[`A component is rendered 1`] = `
               "borderWidth": 1.8748172966652428,
               "elevation": 0,
               "flexDirection": "row",
-              "height": 62.37517146005262,
+              "height": 67.28344314272223,
               "justifyContent": "center",
-              "width": 62.37517146005262,
+              "width": 67.28344314272223,
             }
           }
         >
@@ -2004,9 +2004,9 @@ exports[`A component is rendered 1`] = `
               "borderWidth": 1.8748172966652428,
               "elevation": 0,
               "flexDirection": "row",
-              "height": 62.37517146005262,
+              "height": 67.28344314272223,
               "justifyContent": "center",
-              "width": 62.37517146005262,
+              "width": 67.28344314272223,
             }
           }
         >
@@ -2172,9 +2172,9 @@ exports[`A component is rendered 1`] = `
               "borderWidth": 1.8748172966652428,
               "elevation": 0,
               "flexDirection": "row",
-              "height": 62.37517146005262,
+              "height": 67.28344314272223,
               "justifyContent": "center",
-              "width": 62.37517146005262,
+              "width": 67.28344314272223,
             }
           }
         >
@@ -2244,9 +2244,9 @@ exports[`A component is rendered 1`] = `
               "borderWidth": 1.8748172966652428,
               "elevation": 0,
               "flexDirection": "row",
-              "height": 62.37517146005262,
+              "height": 67.28344314272223,
               "justifyContent": "center",
-              "width": 62.37517146005262,
+              "width": 67.28344314272223,
             }
           }
         >
@@ -2316,9 +2316,9 @@ exports[`A component is rendered 1`] = `
               "borderWidth": 1.8748172966652428,
               "elevation": 0,
               "flexDirection": "row",
-              "height": 62.37517146005262,
+              "height": 67.28344314272223,
               "justifyContent": "center",
-              "width": 62.37517146005262,
+              "width": 67.28344314272223,
             }
           }
         >
@@ -2409,9 +2409,9 @@ exports[`A component is rendered 1`] = `
               "borderWidth": 1.8748172966652428,
               "elevation": 0,
               "flexDirection": "row",
-              "height": 62.37517146005262,
+              "height": 67.28344314272223,
               "justifyContent": "center",
-              "width": 62.37517146005262,
+              "width": 67.28344314272223,
             }
           }
         >
@@ -2479,9 +2479,9 @@ exports[`A component is rendered 1`] = `
               "borderWidth": 0,
               "elevation": 0,
               "flexDirection": "row",
-              "height": 62.37517146005262,
+              "height": 67.28344314272223,
               "justifyContent": "center",
-              "width": 62.37517146005262,
+              "width": 67.28344314272223,
             }
           }
         >
@@ -2495,9 +2495,9 @@ exports[`A component is rendered 1`] = `
                 "borderWidth": 0,
                 "elevation": 0,
                 "flexDirection": "row",
-                "height": 62.37517146005262,
+                "height": 67.28344314272223,
                 "justifyContent": "center",
-                "width": 62.37517146005262,
+                "width": 67.28344314272223,
               }
             }
           />
@@ -2515,9 +2515,9 @@ exports[`A component is rendered 1`] = `
               "borderWidth": 1.8748172966652428,
               "elevation": 0,
               "flexDirection": "row",
-              "height": 62.37517146005262,
+              "height": 67.28344314272223,
               "justifyContent": "center",
-              "width": 62.37517146005262,
+              "width": 67.28344314272223,
             }
           }
         >
@@ -2606,9 +2606,9 @@ exports[`A component is rendered 1`] = `
               "borderWidth": 0,
               "elevation": 0,
               "flexDirection": "row",
-              "height": 62.37517146005262,
+              "height": 67.28344314272223,
               "justifyContent": "center",
-              "width": 62.37517146005262,
+              "width": 67.28344314272223,
             }
           }
         >
@@ -2622,9 +2622,9 @@ exports[`A component is rendered 1`] = `
                 "borderWidth": 0,
                 "elevation": 0,
                 "flexDirection": "row",
-                "height": 62.37517146005262,
+                "height": 67.28344314272223,
                 "justifyContent": "center",
-                "width": 62.37517146005262,
+                "width": 67.28344314272223,
               }
             }
           />
@@ -2640,9 +2640,9 @@ exports[`A component is rendered 1`] = `
               "borderWidth": 0,
               "elevation": 0,
               "flexDirection": "row",
-              "height": 62.37517146005262,
+              "height": 67.28344314272223,
               "justifyContent": "center",
-              "width": 62.37517146005262,
+              "width": 67.28344314272223,
             }
           }
         >
@@ -2656,9 +2656,9 @@ exports[`A component is rendered 1`] = `
                 "borderWidth": 0,
                 "elevation": 0,
                 "flexDirection": "row",
-                "height": 62.37517146005262,
+                "height": 67.28344314272223,
                 "justifyContent": "center",
-                "width": 62.37517146005262,
+                "width": 67.28344314272223,
               }
             }
           />
@@ -2674,9 +2674,9 @@ exports[`A component is rendered 1`] = `
               "borderWidth": 0,
               "elevation": 0,
               "flexDirection": "row",
-              "height": 62.37517146005262,
+              "height": 67.28344314272223,
               "justifyContent": "center",
-              "width": 62.37517146005262,
+              "width": 67.28344314272223,
             }
           }
         >
@@ -2690,9 +2690,9 @@ exports[`A component is rendered 1`] = `
                 "borderWidth": 0,
                 "elevation": 0,
                 "flexDirection": "row",
-                "height": 62.37517146005262,
+                "height": 67.28344314272223,
                 "justifyContent": "center",
-                "width": 62.37517146005262,
+                "width": 67.28344314272223,
               }
             }
           />
@@ -2729,9 +2729,9 @@ exports[`A component is rendered 1`] = `
               "borderWidth": 0,
               "elevation": 0,
               "flexDirection": "row",
-              "height": 62.37517146005262,
+              "height": 67.28344314272223,
               "justifyContent": "center",
-              "width": 62.37517146005262,
+              "width": 67.28344314272223,
             }
           }
         >
@@ -2745,9 +2745,9 @@ exports[`A component is rendered 1`] = `
                 "borderWidth": 0,
                 "elevation": 0,
                 "flexDirection": "row",
-                "height": 62.37517146005262,
+                "height": 67.28344314272223,
                 "justifyContent": "center",
-                "width": 62.37517146005262,
+                "width": 67.28344314272223,
               }
             }
           />
@@ -2763,9 +2763,9 @@ exports[`A component is rendered 1`] = `
               "borderWidth": 0,
               "elevation": 0,
               "flexDirection": "row",
-              "height": 62.37517146005262,
+              "height": 67.28344314272223,
               "justifyContent": "center",
-              "width": 62.37517146005262,
+              "width": 67.28344314272223,
             }
           }
         >
@@ -2779,9 +2779,9 @@ exports[`A component is rendered 1`] = `
                 "borderWidth": 0,
                 "elevation": 0,
                 "flexDirection": "row",
-                "height": 62.37517146005262,
+                "height": 67.28344314272223,
                 "justifyContent": "center",
-                "width": 62.37517146005262,
+                "width": 67.28344314272223,
               }
             }
           />
@@ -2797,9 +2797,9 @@ exports[`A component is rendered 1`] = `
               "borderWidth": 0,
               "elevation": 0,
               "flexDirection": "row",
-              "height": 62.37517146005262,
+              "height": 67.28344314272223,
               "justifyContent": "center",
-              "width": 62.37517146005262,
+              "width": 67.28344314272223,
             }
           }
         >
@@ -2813,9 +2813,9 @@ exports[`A component is rendered 1`] = `
                 "borderWidth": 0,
                 "elevation": 0,
                 "flexDirection": "row",
-                "height": 62.37517146005262,
+                "height": 67.28344314272223,
                 "justifyContent": "center",
-                "width": 62.37517146005262,
+                "width": 67.28344314272223,
               }
             }
           />
@@ -2861,9 +2861,9 @@ exports[`A component is rendered 1`] = `
               "borderWidth": 0,
               "elevation": 0,
               "flexDirection": "row",
-              "height": 62.37517146005262,
+              "height": 67.28344314272223,
               "justifyContent": "center",
-              "width": 62.37517146005262,
+              "width": 67.28344314272223,
             }
           }
         >
@@ -2877,9 +2877,9 @@ exports[`A component is rendered 1`] = `
                 "borderWidth": 0,
                 "elevation": 0,
                 "flexDirection": "row",
-                "height": 62.37517146005262,
+                "height": 67.28344314272223,
                 "justifyContent": "center",
-                "width": 62.37517146005262,
+                "width": 67.28344314272223,
               }
             }
           />
@@ -2895,9 +2895,9 @@ exports[`A component is rendered 1`] = `
               "borderWidth": 0,
               "elevation": 0,
               "flexDirection": "row",
-              "height": 62.37517146005262,
+              "height": 67.28344314272223,
               "justifyContent": "center",
-              "width": 62.37517146005262,
+              "width": 67.28344314272223,
             }
           }
         >
@@ -2911,9 +2911,9 @@ exports[`A component is rendered 1`] = `
                 "borderWidth": 0,
                 "elevation": 0,
                 "flexDirection": "row",
-                "height": 62.37517146005262,
+                "height": 67.28344314272223,
                 "justifyContent": "center",
-                "width": 62.37517146005262,
+                "width": 67.28344314272223,
               }
             }
           />
@@ -2929,9 +2929,9 @@ exports[`A component is rendered 1`] = `
               "borderWidth": 0,
               "elevation": 0,
               "flexDirection": "row",
-              "height": 62.37517146005262,
+              "height": 67.28344314272223,
               "justifyContent": "center",
-              "width": 62.37517146005262,
+              "width": 67.28344314272223,
             }
           }
         >
@@ -2945,9 +2945,9 @@ exports[`A component is rendered 1`] = `
                 "borderWidth": 0,
                 "elevation": 0,
                 "flexDirection": "row",
-                "height": 62.37517146005262,
+                "height": 67.28344314272223,
                 "justifyContent": "center",
-                "width": 62.37517146005262,
+                "width": 67.28344314272223,
               }
             }
           />
@@ -2984,9 +2984,9 @@ exports[`A component is rendered 1`] = `
               "borderWidth": 0,
               "elevation": 0,
               "flexDirection": "row",
-              "height": 62.37517146005262,
+              "height": 67.28344314272223,
               "justifyContent": "center",
-              "width": 62.37517146005262,
+              "width": 67.28344314272223,
             }
           }
         >
@@ -3000,9 +3000,9 @@ exports[`A component is rendered 1`] = `
                 "borderWidth": 0,
                 "elevation": 0,
                 "flexDirection": "row",
-                "height": 62.37517146005262,
+                "height": 67.28344314272223,
                 "justifyContent": "center",
-                "width": 62.37517146005262,
+                "width": 67.28344314272223,
               }
             }
           />
@@ -3020,9 +3020,9 @@ exports[`A component is rendered 1`] = `
               "borderWidth": 1.8748172966652428,
               "elevation": 0,
               "flexDirection": "row",
-              "height": 62.37517146005262,
+              "height": 67.28344314272223,
               "justifyContent": "center",
-              "width": 62.37517146005262,
+              "width": 67.28344314272223,
             }
           }
         >
@@ -3092,9 +3092,9 @@ exports[`A component is rendered 1`] = `
               "borderWidth": 1.8748172966652428,
               "elevation": 0,
               "flexDirection": "row",
-              "height": 62.37517146005262,
+              "height": 67.28344314272223,
               "justifyContent": "center",
-              "width": 62.37517146005262,
+              "width": 67.28344314272223,
             }
           }
         >
@@ -3185,9 +3185,9 @@ exports[`A component is rendered 1`] = `
               "borderWidth": 1.8748172966652428,
               "elevation": 0,
               "flexDirection": "row",
-              "height": 62.37517146005262,
+              "height": 67.28344314272223,
               "justifyContent": "center",
-              "width": 62.37517146005262,
+              "width": 67.28344314272223,
             }
           }
         >
@@ -3257,9 +3257,9 @@ exports[`A component is rendered 1`] = `
               "borderWidth": 1.8748172966652428,
               "elevation": 0,
               "flexDirection": "row",
-              "height": 62.37517146005262,
+              "height": 67.28344314272223,
               "justifyContent": "center",
-              "width": 62.37517146005262,
+              "width": 67.28344314272223,
             }
           }
         >
@@ -3329,9 +3329,9 @@ exports[`A component is rendered 1`] = `
               "borderWidth": 1.8748172966652428,
               "elevation": 0,
               "flexDirection": "row",
-              "height": 62.37517146005262,
+              "height": 67.28344314272223,
               "justifyContent": "center",
-              "width": 62.37517146005262,
+              "width": 67.28344314272223,
             }
           }
         >
@@ -3497,9 +3497,9 @@ exports[`A component is rendered 1`] = `
               "borderWidth": 1.8748172966652428,
               "elevation": 0,
               "flexDirection": "row",
-              "height": 62.37517146005262,
+              "height": 67.28344314272223,
               "justifyContent": "center",
-              "width": 62.37517146005262,
+              "width": 67.28344314272223,
             }
           }
         >
@@ -3569,9 +3569,9 @@ exports[`A component is rendered 1`] = `
               "borderWidth": 1.8748172966652428,
               "elevation": 0,
               "flexDirection": "row",
-              "height": 62.37517146005262,
+              "height": 67.28344314272223,
               "justifyContent": "center",
-              "width": 62.37517146005262,
+              "width": 67.28344314272223,
             }
           }
         >
@@ -3641,9 +3641,9 @@ exports[`A component is rendered 1`] = `
               "borderWidth": 1.8748172966652428,
               "elevation": 0,
               "flexDirection": "row",
-              "height": 62.37517146005262,
+              "height": 67.28344314272223,
               "justifyContent": "center",
-              "width": 62.37517146005262,
+              "width": 67.28344314272223,
             }
           }
         >
@@ -3734,9 +3734,9 @@ exports[`A component is rendered 1`] = `
               "borderWidth": 1.8748172966652428,
               "elevation": 0,
               "flexDirection": "row",
-              "height": 62.37517146005262,
+              "height": 67.28344314272223,
               "justifyContent": "center",
-              "width": 62.37517146005262,
+              "width": 67.28344314272223,
             }
           }
         >
@@ -3804,9 +3804,9 @@ exports[`A component is rendered 1`] = `
               "borderWidth": 0,
               "elevation": 0,
               "flexDirection": "row",
-              "height": 62.37517146005262,
+              "height": 67.28344314272223,
               "justifyContent": "center",
-              "width": 62.37517146005262,
+              "width": 67.28344314272223,
             }
           }
         >
@@ -3820,9 +3820,9 @@ exports[`A component is rendered 1`] = `
                 "borderWidth": 0,
                 "elevation": 0,
                 "flexDirection": "row",
-                "height": 62.37517146005262,
+                "height": 67.28344314272223,
                 "justifyContent": "center",
-                "width": 62.37517146005262,
+                "width": 67.28344314272223,
               }
             }
           />
@@ -3840,9 +3840,9 @@ exports[`A component is rendered 1`] = `
               "borderWidth": 1.8748172966652428,
               "elevation": 0,
               "flexDirection": "row",
-              "height": 62.37517146005262,
+              "height": 67.28344314272223,
               "justifyContent": "center",
-              "width": 62.37517146005262,
+              "width": 67.28344314272223,
             }
           }
         >
@@ -3931,9 +3931,9 @@ exports[`A component is rendered 1`] = `
               "borderWidth": 0,
               "elevation": 0,
               "flexDirection": "row",
-              "height": 62.37517146005262,
+              "height": 67.28344314272223,
               "justifyContent": "center",
-              "width": 62.37517146005262,
+              "width": 67.28344314272223,
             }
           }
         >
@@ -3947,9 +3947,9 @@ exports[`A component is rendered 1`] = `
                 "borderWidth": 0,
                 "elevation": 0,
                 "flexDirection": "row",
-                "height": 62.37517146005262,
+                "height": 67.28344314272223,
                 "justifyContent": "center",
-                "width": 62.37517146005262,
+                "width": 67.28344314272223,
               }
             }
           />
@@ -3965,9 +3965,9 @@ exports[`A component is rendered 1`] = `
               "borderWidth": 0,
               "elevation": 0,
               "flexDirection": "row",
-              "height": 62.37517146005262,
+              "height": 67.28344314272223,
               "justifyContent": "center",
-              "width": 62.37517146005262,
+              "width": 67.28344314272223,
             }
           }
         >
@@ -3981,9 +3981,9 @@ exports[`A component is rendered 1`] = `
                 "borderWidth": 0,
                 "elevation": 0,
                 "flexDirection": "row",
-                "height": 62.37517146005262,
+                "height": 67.28344314272223,
                 "justifyContent": "center",
-                "width": 62.37517146005262,
+                "width": 67.28344314272223,
               }
             }
           />
@@ -3999,9 +3999,9 @@ exports[`A component is rendered 1`] = `
               "borderWidth": 0,
               "elevation": 0,
               "flexDirection": "row",
-              "height": 62.37517146005262,
+              "height": 67.28344314272223,
               "justifyContent": "center",
-              "width": 62.37517146005262,
+              "width": 67.28344314272223,
             }
           }
         >
@@ -4015,9 +4015,9 @@ exports[`A component is rendered 1`] = `
                 "borderWidth": 0,
                 "elevation": 0,
                 "flexDirection": "row",
-                "height": 62.37517146005262,
+                "height": 67.28344314272223,
                 "justifyContent": "center",
-                "width": 62.37517146005262,
+                "width": 67.28344314272223,
               }
             }
           />
@@ -4054,9 +4054,9 @@ exports[`A component is rendered 1`] = `
               "borderWidth": 0,
               "elevation": 0,
               "flexDirection": "row",
-              "height": 62.37517146005262,
+              "height": 67.28344314272223,
               "justifyContent": "center",
-              "width": 62.37517146005262,
+              "width": 67.28344314272223,
             }
           }
         >
@@ -4070,9 +4070,9 @@ exports[`A component is rendered 1`] = `
                 "borderWidth": 0,
                 "elevation": 0,
                 "flexDirection": "row",
-                "height": 62.37517146005262,
+                "height": 67.28344314272223,
                 "justifyContent": "center",
-                "width": 62.37517146005262,
+                "width": 67.28344314272223,
               }
             }
           />
@@ -4088,9 +4088,9 @@ exports[`A component is rendered 1`] = `
               "borderWidth": 0,
               "elevation": 0,
               "flexDirection": "row",
-              "height": 62.37517146005262,
+              "height": 67.28344314272223,
               "justifyContent": "center",
-              "width": 62.37517146005262,
+              "width": 67.28344314272223,
             }
           }
         >
@@ -4104,9 +4104,9 @@ exports[`A component is rendered 1`] = `
                 "borderWidth": 0,
                 "elevation": 0,
                 "flexDirection": "row",
-                "height": 62.37517146005262,
+                "height": 67.28344314272223,
                 "justifyContent": "center",
-                "width": 62.37517146005262,
+                "width": 67.28344314272223,
               }
             }
           />
@@ -4122,9 +4122,9 @@ exports[`A component is rendered 1`] = `
               "borderWidth": 0,
               "elevation": 0,
               "flexDirection": "row",
-              "height": 62.37517146005262,
+              "height": 67.28344314272223,
               "justifyContent": "center",
-              "width": 62.37517146005262,
+              "width": 67.28344314272223,
             }
           }
         >
@@ -4138,9 +4138,9 @@ exports[`A component is rendered 1`] = `
                 "borderWidth": 0,
                 "elevation": 0,
                 "flexDirection": "row",
-                "height": 62.37517146005262,
+                "height": 67.28344314272223,
                 "justifyContent": "center",
-                "width": 62.37517146005262,
+                "width": 67.28344314272223,
               }
             }
           />
@@ -4188,9 +4188,9 @@ exports[`A component is rendered 1`] = `
               "borderWidth": 1.8748172966652428,
               "elevation": 0,
               "flexDirection": "row",
-              "height": 62.37517146005262,
+              "height": 67.28344314272223,
               "justifyContent": "center",
-              "width": 62.37517146005262,
+              "width": 67.28344314272223,
             }
           }
         >
@@ -4281,9 +4281,9 @@ exports[`A component is rendered 1`] = `
               "borderWidth": 1.8748172966652428,
               "elevation": 0,
               "flexDirection": "row",
-              "height": 62.37517146005262,
+              "height": 67.28344314272223,
               "justifyContent": "center",
-              "width": 62.37517146005262,
+              "width": 67.28344314272223,
             }
           }
         >
@@ -4374,9 +4374,9 @@ exports[`A component is rendered 1`] = `
               "borderWidth": 1.8748172966652428,
               "elevation": 0,
               "flexDirection": "row",
-              "height": 62.37517146005262,
+              "height": 67.28344314272223,
               "justifyContent": "center",
-              "width": 62.37517146005262,
+              "width": 67.28344314272223,
             }
           }
         >
@@ -4500,9 +4500,9 @@ exports[`A component is rendered 1`] = `
               "borderWidth": 1.8748172966652428,
               "elevation": 0,
               "flexDirection": "row",
-              "height": 62.37517146005262,
+              "height": 67.28344314272223,
               "justifyContent": "center",
-              "width": 62.37517146005262,
+              "width": 67.28344314272223,
             }
           }
         >
@@ -4593,9 +4593,9 @@ exports[`A component is rendered 1`] = `
               "borderWidth": 1.8748172966652428,
               "elevation": 0,
               "flexDirection": "row",
-              "height": 62.37517146005262,
+              "height": 67.28344314272223,
               "justifyContent": "center",
-              "width": 62.37517146005262,
+              "width": 67.28344314272223,
             }
           }
         >
@@ -4684,9 +4684,9 @@ exports[`A component is rendered 1`] = `
               "borderWidth": 0,
               "elevation": 0,
               "flexDirection": "row",
-              "height": 62.37517146005262,
+              "height": 67.28344314272223,
               "justifyContent": "center",
-              "width": 62.37517146005262,
+              "width": 67.28344314272223,
             }
           }
         >
@@ -4700,9 +4700,9 @@ exports[`A component is rendered 1`] = `
                 "borderWidth": 0,
                 "elevation": 0,
                 "flexDirection": "row",
-                "height": 62.37517146005262,
+                "height": 67.28344314272223,
                 "justifyContent": "center",
-                "width": 62.37517146005262,
+                "width": 67.28344314272223,
               }
             }
           />
@@ -4739,9 +4739,9 @@ exports[`A component is rendered 1`] = `
               "borderWidth": 0,
               "elevation": 0,
               "flexDirection": "row",
-              "height": 62.37517146005262,
+              "height": 67.28344314272223,
               "justifyContent": "center",
-              "width": 62.37517146005262,
+              "width": 67.28344314272223,
             }
           }
         >
@@ -4755,9 +4755,9 @@ exports[`A component is rendered 1`] = `
                 "borderWidth": 0,
                 "elevation": 0,
                 "flexDirection": "row",
-                "height": 62.37517146005262,
+                "height": 67.28344314272223,
                 "justifyContent": "center",
-                "width": 62.37517146005262,
+                "width": 67.28344314272223,
               }
             }
           />

--- a/src/components/harp-face/harp-face.tsx
+++ b/src/components/harp-face/harp-face.tsx
@@ -22,3 +22,14 @@ export const HarpFace = (): React.ReactElement => {
 
   return <View style={styles.face}>{fragments}</View>
 }
+
+export const HarpFaceMemo = (): React.ReactElement => {
+  const [activeHarpStrata] = useGlobal('activeHarpStrata')
+  const [activeDisplayMode] = useGlobal('activeDisplayMode')
+  const [activeExperienceMode] = useGlobal('activeExperienceMode')
+  return React.useMemo(() => <HarpFace />, [
+    activeHarpStrata,
+    activeDisplayMode,
+    activeExperienceMode
+  ])
+}

--- a/src/components/harp-face/harp-face.tsx
+++ b/src/components/harp-face/harp-face.tsx
@@ -24,12 +24,5 @@ export const HarpFace = (): React.ReactElement => {
 }
 
 export const HarpFaceMemo = (): React.ReactElement => {
-  const [activeHarpStrata] = useGlobal('activeHarpStrata')
-  const [activeDisplayMode] = useGlobal('activeDisplayMode')
-  const [activeExperienceMode] = useGlobal('activeExperienceMode')
-  return React.useMemo(() => <HarpFace />, [
-    activeHarpStrata,
-    activeDisplayMode,
-    activeExperienceMode
-  ])
+  return React.useMemo(() => <HarpFace />, [])
 }

--- a/src/components/harp-face/index.ts
+++ b/src/components/harp-face/index.ts
@@ -1,1 +1,1 @@
-export { HarpFace } from './harp-face'
+export { HarpFaceMemo } from './harp-face'

--- a/src/components/harp-guru/harp-guru.tsx
+++ b/src/components/harp-guru/harp-guru.tsx
@@ -8,7 +8,7 @@ import type { ReactElement } from 'react'
 
 import { QuizQuestionDisplay } from '../quiz-question-display'
 import { LayoutMenu } from '../layout-menu'
-import { HarpFace } from '../harp-face'
+import { HarpFaceMemo } from '../harp-face'
 import { CovariantMenu } from '../covariant-menu'
 import { setGlobalState, setGlobalReducers } from '../../utils'
 import { MenuStates } from '../../types'
@@ -49,7 +49,7 @@ export const HarpGuru = (): ReactElement => {
       onHandlerStateChange={handleSwipe}
     >
       <View style={styles.fillScreen}>
-        <HarpFace />
+        <HarpFaceMemo />
         <CovariantMenu
           hideMenu={menuState !== MenuStates.CovariantMenu}
           hideLabel={

--- a/src/components/harp-row/__snapshots__/harp-row.test.tsx.snap
+++ b/src/components/harp-row/__snapshots__/harp-row.test.tsx.snap
@@ -43,9 +43,9 @@ exports[`A snapshot of a blow home row 1`] = `
           "borderWidth": 1.8748172966652428,
           "elevation": 0,
           "flexDirection": "row",
-          "height": 62.37517146005262,
+          "height": 67.28344314272223,
           "justifyContent": "center",
-          "width": 62.37517146005262,
+          "width": 67.28344314272223,
         }
       }
     >
@@ -115,9 +115,9 @@ exports[`A snapshot of a blow home row 1`] = `
           "borderWidth": 1.8748172966652428,
           "elevation": 0,
           "flexDirection": "row",
-          "height": 62.37517146005262,
+          "height": 67.28344314272223,
           "justifyContent": "center",
-          "width": 62.37517146005262,
+          "width": 67.28344314272223,
         }
       }
     >
@@ -187,9 +187,9 @@ exports[`A snapshot of a blow home row 1`] = `
           "borderWidth": 1.8748172966652428,
           "elevation": 0,
           "flexDirection": "row",
-          "height": 62.37517146005262,
+          "height": 67.28344314272223,
           "justifyContent": "center",
-          "width": 62.37517146005262,
+          "width": 67.28344314272223,
         }
       }
     >
@@ -259,9 +259,9 @@ exports[`A snapshot of a blow home row 1`] = `
           "borderWidth": 1.8748172966652428,
           "elevation": 0,
           "flexDirection": "row",
-          "height": 62.37517146005262,
+          "height": 67.28344314272223,
           "justifyContent": "center",
-          "width": 62.37517146005262,
+          "width": 67.28344314272223,
         }
       }
     >
@@ -331,9 +331,9 @@ exports[`A snapshot of a blow home row 1`] = `
           "borderWidth": 1.8748172966652428,
           "elevation": 0,
           "flexDirection": "row",
-          "height": 62.37517146005262,
+          "height": 67.28344314272223,
           "justifyContent": "center",
-          "width": 62.37517146005262,
+          "width": 67.28344314272223,
         }
       }
     >
@@ -403,9 +403,9 @@ exports[`A snapshot of a blow home row 1`] = `
           "borderWidth": 1.8748172966652428,
           "elevation": 0,
           "flexDirection": "row",
-          "height": 62.37517146005262,
+          "height": 67.28344314272223,
           "justifyContent": "center",
-          "width": 62.37517146005262,
+          "width": 67.28344314272223,
         }
       }
     >
@@ -475,9 +475,9 @@ exports[`A snapshot of a blow home row 1`] = `
           "borderWidth": 1.8748172966652428,
           "elevation": 0,
           "flexDirection": "row",
-          "height": 62.37517146005262,
+          "height": 67.28344314272223,
           "justifyContent": "center",
-          "width": 62.37517146005262,
+          "width": 67.28344314272223,
         }
       }
     >
@@ -547,9 +547,9 @@ exports[`A snapshot of a blow home row 1`] = `
           "borderWidth": 1.8748172966652428,
           "elevation": 0,
           "flexDirection": "row",
-          "height": 62.37517146005262,
+          "height": 67.28344314272223,
           "justifyContent": "center",
-          "width": 62.37517146005262,
+          "width": 67.28344314272223,
         }
       }
     >
@@ -619,9 +619,9 @@ exports[`A snapshot of a blow home row 1`] = `
           "borderWidth": 1.8748172966652428,
           "elevation": 0,
           "flexDirection": "row",
-          "height": 62.37517146005262,
+          "height": 67.28344314272223,
           "justifyContent": "center",
-          "width": 62.37517146005262,
+          "width": 67.28344314272223,
         }
       }
     >
@@ -691,9 +691,9 @@ exports[`A snapshot of a blow home row 1`] = `
           "borderWidth": 1.8748172966652428,
           "elevation": 0,
           "flexDirection": "row",
-          "height": 62.37517146005262,
+          "height": 67.28344314272223,
           "justifyContent": "center",
-          "width": 62.37517146005262,
+          "width": 67.28344314272223,
         }
       }
     >
@@ -797,9 +797,9 @@ exports[`A snapshot of a draw home row 1`] = `
           "borderWidth": 1.8748172966652428,
           "elevation": 0,
           "flexDirection": "row",
-          "height": 62.37517146005262,
+          "height": 67.28344314272223,
           "justifyContent": "center",
-          "width": 62.37517146005262,
+          "width": 67.28344314272223,
         }
       }
     >
@@ -869,9 +869,9 @@ exports[`A snapshot of a draw home row 1`] = `
           "borderWidth": 1.8748172966652428,
           "elevation": 0,
           "flexDirection": "row",
-          "height": 62.37517146005262,
+          "height": 67.28344314272223,
           "justifyContent": "center",
-          "width": 62.37517146005262,
+          "width": 67.28344314272223,
         }
       }
     >
@@ -941,9 +941,9 @@ exports[`A snapshot of a draw home row 1`] = `
           "borderWidth": 1.8748172966652428,
           "elevation": 0,
           "flexDirection": "row",
-          "height": 62.37517146005262,
+          "height": 67.28344314272223,
           "justifyContent": "center",
-          "width": 62.37517146005262,
+          "width": 67.28344314272223,
         }
       }
     >
@@ -1013,9 +1013,9 @@ exports[`A snapshot of a draw home row 1`] = `
           "borderWidth": 1.8748172966652428,
           "elevation": 0,
           "flexDirection": "row",
-          "height": 62.37517146005262,
+          "height": 67.28344314272223,
           "justifyContent": "center",
-          "width": 62.37517146005262,
+          "width": 67.28344314272223,
         }
       }
     >
@@ -1085,9 +1085,9 @@ exports[`A snapshot of a draw home row 1`] = `
           "borderWidth": 1.8748172966652428,
           "elevation": 0,
           "flexDirection": "row",
-          "height": 62.37517146005262,
+          "height": 67.28344314272223,
           "justifyContent": "center",
-          "width": 62.37517146005262,
+          "width": 67.28344314272223,
         }
       }
     >
@@ -1157,9 +1157,9 @@ exports[`A snapshot of a draw home row 1`] = `
           "borderWidth": 1.8748172966652428,
           "elevation": 0,
           "flexDirection": "row",
-          "height": 62.37517146005262,
+          "height": 67.28344314272223,
           "justifyContent": "center",
-          "width": 62.37517146005262,
+          "width": 67.28344314272223,
         }
       }
     >
@@ -1229,9 +1229,9 @@ exports[`A snapshot of a draw home row 1`] = `
           "borderWidth": 1.8748172966652428,
           "elevation": 0,
           "flexDirection": "row",
-          "height": 62.37517146005262,
+          "height": 67.28344314272223,
           "justifyContent": "center",
-          "width": 62.37517146005262,
+          "width": 67.28344314272223,
         }
       }
     >
@@ -1301,9 +1301,9 @@ exports[`A snapshot of a draw home row 1`] = `
           "borderWidth": 1.8748172966652428,
           "elevation": 0,
           "flexDirection": "row",
-          "height": 62.37517146005262,
+          "height": 67.28344314272223,
           "justifyContent": "center",
-          "width": 62.37517146005262,
+          "width": 67.28344314272223,
         }
       }
     >
@@ -1373,9 +1373,9 @@ exports[`A snapshot of a draw home row 1`] = `
           "borderWidth": 1.8748172966652428,
           "elevation": 0,
           "flexDirection": "row",
-          "height": 62.37517146005262,
+          "height": 67.28344314272223,
           "justifyContent": "center",
-          "width": 62.37517146005262,
+          "width": 67.28344314272223,
         }
       }
     >
@@ -1445,9 +1445,9 @@ exports[`A snapshot of a draw home row 1`] = `
           "borderWidth": 1.8748172966652428,
           "elevation": 0,
           "flexDirection": "row",
-          "height": 62.37517146005262,
+          "height": 67.28344314272223,
           "justifyContent": "center",
-          "width": 62.37517146005262,
+          "width": 67.28344314272223,
         }
       }
     >
@@ -1549,9 +1549,9 @@ exports[`A snapshot of a non-home row 1`] = `
           "borderWidth": 0,
           "elevation": 0,
           "flexDirection": "row",
-          "height": 62.37517146005262,
+          "height": 67.28344314272223,
           "justifyContent": "center",
-          "width": 62.37517146005262,
+          "width": 67.28344314272223,
         }
       }
     >
@@ -1565,9 +1565,9 @@ exports[`A snapshot of a non-home row 1`] = `
             "borderWidth": 0,
             "elevation": 0,
             "flexDirection": "row",
-            "height": 62.37517146005262,
+            "height": 67.28344314272223,
             "justifyContent": "center",
-            "width": 62.37517146005262,
+            "width": 67.28344314272223,
           }
         }
       />
@@ -1583,9 +1583,9 @@ exports[`A snapshot of a non-home row 1`] = `
           "borderWidth": 0,
           "elevation": 0,
           "flexDirection": "row",
-          "height": 62.37517146005262,
+          "height": 67.28344314272223,
           "justifyContent": "center",
-          "width": 62.37517146005262,
+          "width": 67.28344314272223,
         }
       }
     >
@@ -1599,9 +1599,9 @@ exports[`A snapshot of a non-home row 1`] = `
             "borderWidth": 0,
             "elevation": 0,
             "flexDirection": "row",
-            "height": 62.37517146005262,
+            "height": 67.28344314272223,
             "justifyContent": "center",
-            "width": 62.37517146005262,
+            "width": 67.28344314272223,
           }
         }
       />
@@ -1617,9 +1617,9 @@ exports[`A snapshot of a non-home row 1`] = `
           "borderWidth": 0,
           "elevation": 0,
           "flexDirection": "row",
-          "height": 62.37517146005262,
+          "height": 67.28344314272223,
           "justifyContent": "center",
-          "width": 62.37517146005262,
+          "width": 67.28344314272223,
         }
       }
     >
@@ -1633,9 +1633,9 @@ exports[`A snapshot of a non-home row 1`] = `
             "borderWidth": 0,
             "elevation": 0,
             "flexDirection": "row",
-            "height": 62.37517146005262,
+            "height": 67.28344314272223,
             "justifyContent": "center",
-            "width": 62.37517146005262,
+            "width": 67.28344314272223,
           }
         }
       />
@@ -1651,9 +1651,9 @@ exports[`A snapshot of a non-home row 1`] = `
           "borderWidth": 0,
           "elevation": 0,
           "flexDirection": "row",
-          "height": 62.37517146005262,
+          "height": 67.28344314272223,
           "justifyContent": "center",
-          "width": 62.37517146005262,
+          "width": 67.28344314272223,
         }
       }
     >
@@ -1667,9 +1667,9 @@ exports[`A snapshot of a non-home row 1`] = `
             "borderWidth": 0,
             "elevation": 0,
             "flexDirection": "row",
-            "height": 62.37517146005262,
+            "height": 67.28344314272223,
             "justifyContent": "center",
-            "width": 62.37517146005262,
+            "width": 67.28344314272223,
           }
         }
       />
@@ -1685,9 +1685,9 @@ exports[`A snapshot of a non-home row 1`] = `
           "borderWidth": 0,
           "elevation": 0,
           "flexDirection": "row",
-          "height": 62.37517146005262,
+          "height": 67.28344314272223,
           "justifyContent": "center",
-          "width": 62.37517146005262,
+          "width": 67.28344314272223,
         }
       }
     >
@@ -1701,9 +1701,9 @@ exports[`A snapshot of a non-home row 1`] = `
             "borderWidth": 0,
             "elevation": 0,
             "flexDirection": "row",
-            "height": 62.37517146005262,
+            "height": 67.28344314272223,
             "justifyContent": "center",
-            "width": 62.37517146005262,
+            "width": 67.28344314272223,
           }
         }
       />
@@ -1719,9 +1719,9 @@ exports[`A snapshot of a non-home row 1`] = `
           "borderWidth": 0,
           "elevation": 0,
           "flexDirection": "row",
-          "height": 62.37517146005262,
+          "height": 67.28344314272223,
           "justifyContent": "center",
-          "width": 62.37517146005262,
+          "width": 67.28344314272223,
         }
       }
     >
@@ -1735,9 +1735,9 @@ exports[`A snapshot of a non-home row 1`] = `
             "borderWidth": 0,
             "elevation": 0,
             "flexDirection": "row",
-            "height": 62.37517146005262,
+            "height": 67.28344314272223,
             "justifyContent": "center",
-            "width": 62.37517146005262,
+            "width": 67.28344314272223,
           }
         }
       />
@@ -1753,9 +1753,9 @@ exports[`A snapshot of a non-home row 1`] = `
           "borderWidth": 0,
           "elevation": 0,
           "flexDirection": "row",
-          "height": 62.37517146005262,
+          "height": 67.28344314272223,
           "justifyContent": "center",
-          "width": 62.37517146005262,
+          "width": 67.28344314272223,
         }
       }
     >
@@ -1769,9 +1769,9 @@ exports[`A snapshot of a non-home row 1`] = `
             "borderWidth": 0,
             "elevation": 0,
             "flexDirection": "row",
-            "height": 62.37517146005262,
+            "height": 67.28344314272223,
             "justifyContent": "center",
-            "width": 62.37517146005262,
+            "width": 67.28344314272223,
           }
         }
       />
@@ -1787,9 +1787,9 @@ exports[`A snapshot of a non-home row 1`] = `
           "borderWidth": 0,
           "elevation": 0,
           "flexDirection": "row",
-          "height": 62.37517146005262,
+          "height": 67.28344314272223,
           "justifyContent": "center",
-          "width": 62.37517146005262,
+          "width": 67.28344314272223,
         }
       }
     >
@@ -1803,9 +1803,9 @@ exports[`A snapshot of a non-home row 1`] = `
             "borderWidth": 0,
             "elevation": 0,
             "flexDirection": "row",
-            "height": 62.37517146005262,
+            "height": 67.28344314272223,
             "justifyContent": "center",
-            "width": 62.37517146005262,
+            "width": 67.28344314272223,
           }
         }
       />
@@ -1821,9 +1821,9 @@ exports[`A snapshot of a non-home row 1`] = `
           "borderWidth": 0,
           "elevation": 0,
           "flexDirection": "row",
-          "height": 62.37517146005262,
+          "height": 67.28344314272223,
           "justifyContent": "center",
-          "width": 62.37517146005262,
+          "width": 67.28344314272223,
         }
       }
     >
@@ -1837,9 +1837,9 @@ exports[`A snapshot of a non-home row 1`] = `
             "borderWidth": 0,
             "elevation": 0,
             "flexDirection": "row",
-            "height": 62.37517146005262,
+            "height": 67.28344314272223,
             "justifyContent": "center",
-            "width": 62.37517146005262,
+            "width": 67.28344314272223,
           }
         }
       />
@@ -1857,9 +1857,9 @@ exports[`A snapshot of a non-home row 1`] = `
           "borderWidth": 1.8748172966652428,
           "elevation": 0,
           "flexDirection": "row",
-          "height": 62.37517146005262,
+          "height": 67.28344314272223,
           "justifyContent": "center",
-          "width": 62.37517146005262,
+          "width": 67.28344314272223,
         }
       }
     >

--- a/src/utils/get-next-quiz-question/get-next-quiz-question.ts
+++ b/src/utils/get-next-quiz-question/get-next-quiz-question.ts
@@ -1,4 +1,10 @@
-import { getPitchIds, getPitch, getDegreeIds, isPitchId, isNaturalPitch } from 'harpstrata'
+import {
+  getPitchIds,
+  getPitch,
+  getDegreeIds,
+  isPitchId,
+  isNaturalPitch,
+} from 'harpstrata'
 import type { PitchIds, DegreeIds } from 'harpstrata'
 
 import { DisplayModes } from '../../types'


### PR DESCRIPTION
HarpGuru maintains some state which helps it know when to rerender the
menu's. Since a change in the state will trigger a full rerender of the
HarpGuru object, the HarpFace was previously getting rerendered during
interactions which only relate to the visibility of the menu's.

This appears to have had an improvement on the HarpCell responsiveness
to interactions too. I suspect this is becuase even during this
interaction, several rerenders were being triggered either on the
HarpCells or further up.

I wonder whether I've just created a mask for a more fundamental issue
with the data model by doing this. I need to raise an issue to remove
all momoization and test for the root causes of multiple rerenders later
on.